### PR TITLE
runtimeArgs / runtimeArguments bug fixed

### DIFF
--- a/webkit/webKitDebugAdapter.ts
+++ b/webkit/webKitDebugAdapter.ts
@@ -90,8 +90,8 @@ export class WebKitDebugAdapter implements IDebugAdapter {
 
         // Also start with extra stuff disabled
         chromeArgs.push(...['--no-first-run', '--no-default-browser-check']);
-        if (args.runtimeArguments) {
-            chromeArgs.push(...args.runtimeArguments);
+        if (args.runtimeArgs) {
+            chromeArgs.push(...args.runtimeArgs);
         }
 
         let launchUrl: string;


### PR DESCRIPTION
There was a mixup of the properties runtimeArgs and runtimeArguments causing them not to function properly.
runtimeArgs in the launch.json was mistakenly used as runtimeArguments.